### PR TITLE
Convert fonts to CLX

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,9 +14,15 @@ main() {
 }
 
 build_fonts_mpq() {
+  if ! which pcx2clx; then
+    echo "Please install pcx2clx from https://github.com/diasurgical/devilutionx-graphics-tools/"
+    exit 1
+  fi
   rm -f fonts.mpq
-  cd assets
-  find * -type f -exec smpq -M 1 -C BZIP2 -c ../fonts.mpq '{}' '+'
+  mkdir -p build/fonts
+  pcx2clx --output-dir build/fonts --transparent-color 1 --num-sprites 256 --quiet assets/fonts/*.pcx
+  cd build
+  find fonts -type f -exec smpq -M 1 -C BZIP2 -c ../fonts.mpq '{}' '+'
   cd -
 }
 


### PR DESCRIPTION
Fonts are loaded as CLX as of https://github.com/diasurgical/devilutionX/pull/5183

Fonts size: 167 MiB -> 115 MiB
fonts.mpq size: 52 MiB -> 56 MiB (CLX does not compress as well with BZIP2)